### PR TITLE
Self-host fonts via Astro Fonts to prevent CLS

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config'
+import { defineConfig, fontProviders } from 'astro/config'
 import cloudflare from '@astrojs/cloudflare'
 import sitemap from '@astrojs/sitemap'
 
@@ -20,5 +20,34 @@ export default defineConfig({
     },
   }),
   site: 'https://www.hawkings.me',
+  fonts: [
+    {
+      provider: fontProviders.google(),
+      name: 'Bricolage Grotesque',
+      cssVariable: '--font-bricolage',
+      weights: ['500 700'],
+      styles: ['normal'],
+      subsets: ['latin'],
+      fallbacks: ['sans-serif'],
+    },
+    {
+      provider: fontProviders.google(),
+      name: 'Instrument Sans',
+      cssVariable: '--font-instrument',
+      weights: [400, 500, 600],
+      styles: ['normal'],
+      subsets: ['latin'],
+      fallbacks: ['system-ui', 'sans-serif'],
+    },
+    {
+      provider: fontProviders.google(),
+      name: 'Geist Mono',
+      cssVariable: '--font-geist-mono',
+      weights: [400, 500],
+      styles: ['normal'],
+      subsets: ['latin'],
+      fallbacks: ['monospace'],
+    },
+  ],
   integrations: [sitemap()],
 })

--- a/src/components/PhysicsDock.astro
+++ b/src/components/PhysicsDock.astro
@@ -143,7 +143,7 @@
     background: transparent;
     color: var(--faint);
     cursor: pointer;
-    font-family: 'Geist Mono', monospace;
+    font-family: var(--font-geist-mono);
     font-size: 10.5px;
     letter-spacing: 0.12em;
     opacity: 0.55;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { Font } from 'astro:assets'
 import SiteNav from '~/components/SiteNav.astro'
 import '~/styles/global.css'
 
@@ -19,8 +20,6 @@ const canonicalPath =
   Astro.url.pathname === '/' ? '/' : `${Astro.url.pathname.replace(/\/$/, '')}/`
 const canonical = new URL(canonicalPath, Astro.site)
 const ogImage = new URL(image, Astro.site)
-const fontHref =
-  'https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,500;12..96,600;12..96,700&family=Geist+Mono:wght@400;500&family=Instrument+Sans:wght@400;500;600&display=swap'
 const structuredData = {
   '@context': 'https://schema.org',
   '@graph': [
@@ -84,17 +83,9 @@ const structuredData = {
             ? 'dark'
             : 'light'
     </script>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href={fontHref}
-      onload={'this.onload=null;this.rel="stylesheet"'}
-    />
-    <noscript>
-      <link rel="stylesheet" href={fontHref} />
-    </noscript>
+    <Font cssVariable="--font-bricolage" preload />
+    <Font cssVariable="--font-instrument" />
+    <Font cssVariable="--font-geist-mono" />
     <meta name="description" content={description} />
     {noIndex && <meta name="robots" content="noindex" />}
     <link rel="canonical" href={canonical} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -53,7 +53,7 @@ body {
   overflow-x: hidden;
   background: var(--sky-1);
   color: var(--ink);
-  font-family: 'Instrument Sans', system-ui, sans-serif;
+  font-family: var(--font-instrument);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -205,7 +205,7 @@ textarea {
 
 .brand {
   color: var(--ink);
-  font-family: 'Bricolage Grotesque', sans-serif;
+  font-family: var(--font-bricolage);
   font-size: 17px;
   font-weight: 700;
   letter-spacing: 0;
@@ -292,7 +292,7 @@ textarea {
 h1,
 h2,
 h3 {
-  font-family: 'Bricolage Grotesque', sans-serif;
+  font-family: var(--font-bricolage);
 }
 
 .hero h1 {
@@ -358,7 +358,7 @@ h3 {
 .footer {
   padding: 10px 0 40px;
   color: var(--faint);
-  font-family: 'Geist Mono', monospace;
+  font-family: var(--font-geist-mono);
   font-size: 11.5px;
   letter-spacing: 0.06em;
   text-align: center;


### PR DESCRIPTION
Replaces the Google Fonts preload-stylesheet swap with the built-in fonts config: files are downloaded at build time and served from /_astro/fonts with metric-matched fallbacks, eliminating the cross-origin requests and the font-swap layout shift (CLS 0.227). Only the Bricolage hero font is preloaded.